### PR TITLE
Use ephemeral port in SIRDServerSuite

### DIFF
--- a/play-refined/src/test/scala/be/venneborg/refined/play/SIRDServerSuite.scala
+++ b/play-refined/src/test/scala/be/venneborg/refined/play/SIRDServerSuite.scala
@@ -57,65 +57,66 @@ class SIRDServerSuite extends FunSuite with ScalaFutures with Matchers with Befo
   }
 
   test("refined string in path") {
-    wsClient.url("http://localhost:9000/strings/foo").get().futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/strings/").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/strings/foo").get().futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/strings/").get().futureValue.status shouldBe 404
   }
 
   test("refined string in query") {
-    wsClient.url("http://localhost:9000/query?s=foo").get().futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/query?s=").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/query?s=foo").get().futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/query?s=").get().futureValue.status shouldBe 404
   }
 
   test("refined int in path") {
-    wsClient.url("http://localhost:9000/ints/5").get().futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/ints/-5").get().futureValue.status shouldBe 404
-    wsClient.url("http://localhost:9000/ints/foo").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/ints/5").get().futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/ints/-5").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/ints/foo").get().futureValue.status shouldBe 404
   }
 
   test("refined int in query") {
-    wsClient.url("http://localhost:9000/query?i=5").get().futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/query?i=foo").get().futureValue.status shouldBe 404
-    wsClient.url("http://localhost:9000/query?i=-5").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/query?i=5").get().futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/query?i=foo").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/query?i=-5").get().futureValue.status shouldBe 404
   }
 
   test("refined long in path") {
-    wsClient.url("http://localhost:9000/longs/-5").get().futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/longs/5").get().futureValue.status shouldBe 404
-    wsClient.url("http://localhost:9000/longs/foo").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/longs/-5").get().futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/longs/5").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/longs/foo").get().futureValue.status shouldBe 404
   }
 
   test("refined long in query") {
-    wsClient.url("http://localhost:9000/query?l=-5").get().futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/query?l=foo").get().futureValue.status shouldBe 404
-    wsClient.url("http://localhost:9000/query?l=5").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/query?l=-5").get().futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/query?l=foo").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/query?l=5").get().futureValue.status shouldBe 404
   }
 
   test("refined double in path") {
-    wsClient.url("http://localhost:9000/doubles/12.0").get().futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/doubles/5.0").get().futureValue.status shouldBe 404
-    wsClient.url("http://localhost:9000/doubles/foo").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/doubles/12.0").get().futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/doubles/5.0").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/doubles/foo").get().futureValue.status shouldBe 404
   }
 
   test("refined double in query") {
-    wsClient.url("http://localhost:9000/query?d=12.0").get().futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/query?d=foo").get().futureValue.status shouldBe 404
-    wsClient.url("http://localhost:9000/query?d=5.0").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/query?d=12.0").get().futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/query?d=foo").get().futureValue.status shouldBe 404
+    wsClient.url(s"http://localhost:$port/query?d=5.0").get().futureValue.status shouldBe 404
   }
 
   test("post refined form") {
-    wsClient.url("http://localhost:9000/form").post(tc.asMap).futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/form").post(tc.asMap - "rs").futureValue.status shouldBe 400
+    wsClient.url(s"http://localhost:$port/form").post(tc.asMap).futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/form").post(tc.asMap - "rs").futureValue.status shouldBe 400
   }
 
   test("post refined json") {
     import RefinedJsonFormats._
     implicit val tcFormat = Json.format[TestClass]
 
-    wsClient.url("http://localhost:9000/json").post(Json.toJson(tc)).futureValue.status shouldBe 200
-    wsClient.url("http://localhost:9000/json").post(Json.toJson(tc).transform((__ \ 'rs).json.prune).get).futureValue.status shouldBe 400
+    wsClient.url(s"http://localhost:$port/json").post(Json.toJson(tc)).futureValue.status shouldBe 200
+    wsClient.url(s"http://localhost:$port/json").post(Json.toJson(tc).transform((__ \ 'rs).json.prune).get).futureValue.status shouldBe 400
   }
 
   var server: Option[Server] = None
+  def port: Int = server.flatMap(_.httpPort).getOrElse(9000)
   var wsClient: AhcWSClient = _
 
   override protected def beforeAll() = {

--- a/play26-refined/src/test/scala/be/venneborg/refined/play/SIRDHelper.scala
+++ b/play26-refined/src/test/scala/be/venneborg/refined/play/SIRDHelper.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.JsonBodyWritables
 import play.api.mvc.request.RequestTarget
 import play.api.mvc._
 import play.api.routing.Router.Routes
-import play.core.server.{NettyServer, Server}
+import play.core.server.{NettyServer, Server, ServerConfig}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -30,7 +30,7 @@ object SIRDHelper {
 
   def shutdown(): Future[Any] = actorSystem.terminate()
 
-  def startWithRoutes(routes: Routes): Server = NettyServer.fromRouterWithComponents()(_ => routes)
+  def startWithRoutes(routes: Routes): Server = NettyServer.fromRouterWithComponents(ServerConfig(port = Some(0)))(_ => routes)
 
   def reqHeaderAt(_method: String, _uri: String) = new RequestHeader {
 


### PR DESCRIPTION
This avoids failures when running the suite in parallel for different Play
versions which were all trying to bind to the same port.

Fixes #51.